### PR TITLE
Added Supplier interface as an option

### DIFF
--- a/summer-core/src/main/java/org/greeneyed/summer/monitoring/LogOperationAspect.java
+++ b/summer-core/src/main/java/org/greeneyed/summer/monitoring/LogOperationAspect.java
@@ -24,8 +24,6 @@ package org.greeneyed.summer.monitoring;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.security.Principal;
 import java.util.List;
 import java.util.function.Supplier;

--- a/summer-core/src/main/java/org/greeneyed/summer/monitoring/LogOperationAspect.java
+++ b/summer-core/src/main/java/org/greeneyed/summer/monitoring/LogOperationAspect.java
@@ -24,8 +24,11 @@ package org.greeneyed.summer.monitoring;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.security.Principal;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -82,6 +85,8 @@ public class LogOperationAspect {
             if (args.length > 0 && args[0] != null) {
                 if (args[0] instanceof IdentifiedUser) {
                     userID = ((IdentifiedUser) args[0]).getName();
+                } else if (args[0] instanceof Supplier) {
+                    userID = ((Supplier<?>) args[0]).get().toString();
                 } else if (args[0] instanceof Principal) {
                     userID = ((Principal) args[0]).getName();
                 }


### PR DESCRIPTION
If a parameter decorated with LogOperationAspect has a Supplier as first
parameter, it will be considered the Principal.

This fixes #56 